### PR TITLE
Case sensitivity for ODBC 18.

### DIFF
--- a/src/Models/Quote.php
+++ b/src/Models/Quote.php
@@ -14,8 +14,8 @@ class Quote extends Model
     const UPDATED_AT = 'UpdatedAt';
 
     protected $fillable = [
-        'CustomerID',
-        'QuoteID',
+        'CustomerId',
+        'QuoteId',
         'MpanNumber',
         'ExportTariff',
         'FeedInTariff',
@@ -23,6 +23,6 @@ class Quote extends Model
 
     public function customer()
     {
-        return $this->belongsTo(Customer::class, 'CustomerID', 'Id');
+        return $this->belongsTo(Customer::class, 'CustomerId', 'Id');
     }
 }

--- a/src/Services/CustomerService.php
+++ b/src/Services/CustomerService.php
@@ -419,8 +419,8 @@ class CustomerService
         }
 
         return Quote::create([
-            'CustomerID' => $this->customer->Id,
-            'QuoteID' => $this->attrs['model_id'],
+            'CustomerId' => $this->customer->Id,
+            'QuoteId' => $this->attrs['model_id'],
             'MpanNumber' => $this->attrs['mpan_number'] ?? null,
             'ExportTariff' => $this->attrs['export_tariff'] ?? null,
             'FeedInTariff' => $this->attrs['feed_in_tariff'] ?? null,


### PR DESCRIPTION
During testing, I noticed that the case sensitivity of the ODBC driver is now strict. This means a few fields need to be updated to match the case of the database. 

This could be a niche issue, but it's worth correcting for consistency and future compatibility.